### PR TITLE
remove Click card to see more details when card empty

### DIFF
--- a/js/swipe.js
+++ b/js/swipe.js
@@ -381,13 +381,15 @@ function handleViewedCard(id) {
 function checkIfAllSwiped() {
     const endScreen = document.getElementById("end-screen");
     const cardContainer = document.getElementById("card-container");
-    // const resetButton = document.querySelector('.button-type3');
     const swipeButtons = document.querySelector('.swipe-buttons');
+    const cardHint = document.querySelector('.card-hint');
 
     // hide cardContainer
     cardContainer.style.display = "none";
     // hide swipe buttons
     swipeButtons.style.display = "none";
+    // hide card hint
+    if (cardHint) cardHint.style.display = "none";
     // display end screen
     endScreen.style.display = "block";
 


### PR DESCRIPTION
### 📌 Description

Updated the swipe UI logic to hide the hint text *"Click card to see more details"* when there are no more cards to display. This ensures a cleaner and more accurate user experience on the end screen.

Closes #223

---

### ✅ Type of Change

* [x] Bug fix 🐛
* [ ] New feature ✨
* [ ] Breaking change 💥
* [ ] Documentation update 📚
* [ ] Refactoring 🔧
* [ ] Tests added ✅

---

### 🔍 How Has This Been Tested?

* [x] Manual tests: Swiped through all cards and confirmed the hint is properly hidden when the card container is empty.
* [ ] Unit tests
* [ ] CI/CD passed

---

### 📝 Checklist

* [x] I have followed the contributing guidelines.
* [x] My code has been reviewed by at least one peer.
* [ ] I have added tests if applicable.
* [ ] I have updated the documentation if needed.
* [x] No sensitive information is included.

---

### 📎 Screenshots (if applicable)

<img width="407" alt="Screenshot 2025-06-08 at 23 12 45" src="https://github.com/user-attachments/assets/7e62534c-34ca-4c02-aacf-0366948013c6" />
<img width="640" alt="Screenshot 2025-06-08 at 23 12 55" src="https://github.com/user-attachments/assets/d252ea2e-e48d-4521-a7a6-21507fb8af97" />


---

### 📚 Additional Context

This resolves a minor UI inconsistency that could confuse users once all swipe options have been viewed.
